### PR TITLE
SiftCost_1修改，避免了没有特征点匹配时程序runtime_error

### DIFF
--- a/pso_training/CostFunc/SiftCost.cpp
+++ b/pso_training/CostFunc/SiftCost.cpp
@@ -97,6 +97,8 @@ double SiftCost::costOfMismatch(int index)                                      
     int nomatch=keyPointNum-matchs[index].size();
     if (nomatch<=keyPointNum*toleranceOfNoMatch) cost=0;
     else cost=pow(nomatch-keyPointNum*toleranceOfNoMatch,2);
+    if (Sys[index].size()<=minKeyPointNum) cost+=1000;
+    if (Sx.size()<=minKeyPointNum) cost+=1000;
 #ifdef DEBUG
     std::cout<<"costOfMismatch in match "<<index<<":"<<cost<<std::endl;
 #endif

--- a/pso_training/CostFunc/SiftCost.h
+++ b/pso_training/CostFunc/SiftCost.h
@@ -13,8 +13,8 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "SiftParams.h"
-#include "../pso/ICostFunction.h"
-#include "../../cds/cds.h"
+#include "pso/ICostFunction.h"
+#include "../cds/cds.h"
 
 #ifndef Eps
 #define Eps 0.000001
@@ -22,6 +22,9 @@
 #ifndef maxProportation
 #define maxProportation 100000
 #endif // maxProportation
+#ifndef minKeyPointNum
+#define minKeyPointNum 20
+#endif
 //#define DEBUG
 /*
 使用方法：

--- a/pso_training/CostFunc/SiftCost_1.cpp
+++ b/pso_training/CostFunc/SiftCost_1.cpp
@@ -5,6 +5,7 @@ double SiftCost_1::costOfWrongMatch(int index){
     double temp[6];
     std::vector<cv::DMatch>& match=matchs[index];
     std::vector<cv::KeyPoint>& Sy=Sys[index];
+    if (match.size()==0) return 0;
     for(int i=0;i<match.size();i++){                                          //本质：(x,y,1)*(a11,a12|a21,a22|a31,a32)=(x*|y*)  其中1为平移项，|代表矩阵中换行。这段循环是将其化为向量形式
         temp[0]=Sy[match[i].trainIdx].pt.x,temp[1]=Sy[match[i].trainIdx].pt.y,temp[2]=1;
         temp[3]=0,temp[4]=0,temp[5]=0;

--- a/pso_training/pso/ICostFunction.h
+++ b/pso_training/pso/ICostFunction.h
@@ -1,0 +1,18 @@
+#ifndef COSTFUNCTION_H
+#define COSTFUNCTION_H
+
+#include <iostream>
+#include <cmath>
+#include <vector>
+
+#include "IParams.h"
+
+template <typename _ParamsType>
+class ICostFunction {
+public:
+	typedef _ParamsType ParamsType;
+	virtual double costFunction(const _ParamsType&) = 0;
+};
+
+
+#endif

--- a/pso_training/pso/IParams.h
+++ b/pso_training/pso/IParams.h
@@ -23,7 +23,7 @@ public:
 
 	cv::Mat toMat() const {
 		cv::Mat res(0, 0, CV_64F);
-		for (auto i : params) res.push_back(i);
+        for (auto i : params) res.push_back(i);
 		res = res.reshape(1, params.size());
 		return res;
 	}

--- a/pso_training/pso/particle.h
+++ b/pso_training/pso/particle.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <cmath>
 
-#include "icostfunction.h"
+#include "ICostFunction.h"
 
 #define COST_INF (9e60)
 

--- a/pso_training/pso/pso.h
+++ b/pso_training/pso/pso.h
@@ -16,7 +16,7 @@ class Pso
 	const int particle_num, generation, kmeans_generation, kmeans_k;
 	std::pair<double, cv::Mat> *swarm_best_position;
 	cv::Mat last_best_position;
-	std::vector<Particle<ParamsType>> particles;
+    std::vector<Particle<ParamsType> > particles;
 	int *swarm_id_of_particles;
 	double best_cost;
 	cv::Mat *kmeans_centroid;


### PR DESCRIPTION
改的比较粗糙。不过不影响使用，最多只是可以改进一下看能否提升一点pso训练效果。
大家先用用看吧。
